### PR TITLE
Revert "force nio4r ~> 1.2.1. 2.0.0 is for ruby 2.2.2+ only"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rake', '~>10.4.2'
 gem 'berkshelf', '~>4.0'
-gem 'nio4r', '~>1.2.1'
 
 group :spec do
   gem 'rspec', '>=3.4', '<3.5'


### PR DESCRIPTION
Reverts cloudpassage/cloudpassage-chef-cookbook#55