### PR TITLE
v4.0.3 merge from develop to master

### DIFF
--- a/.kitchen.windows.yml
+++ b/.kitchen.windows.yml
@@ -25,9 +25,6 @@ platforms:
   - name: windows-2012r2
     driver:
       image_id: <%= ENV['WIN_2012_R2_AMI_ID'] %>
-  - name: windows-2008r2ps1
-    driver:
-      image_id: <%= ENV['WIN_2008_R2_AMI_ID'] %>
 suites:
   - name: default
     run_list:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
   - 2.3.3
 env:
-  - CHEF_DK_VERSION=1.4.3
+  - CHEF_DK_VERSION=2.5.3
 
 sudo: required
 
@@ -11,10 +11,10 @@ install:
 script:
   - chef exec berks install
   - chef exec rake travis
+  - chef exec rake integration:windows
   - chef exec rake integration:ubuntu
   - chef exec rake integration:rhel
   - chef exec rake integration:amzn
   - chef exec rake integration:centos
   - chef exec rake integration:debian
   - chef exec rake integration:oracle
-  - chef exec rake integration:windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,3 +156,9 @@
 ## 4.0.2
 
 * Update Agent version to 4.1.1 (Linux) and 4.1.0 (Windows)
+
+## 4.0.3
+
+* Update Agent version to 4.1.6 (Linux) and 4.1.3 (Windows)
+* Update vulnerable Gem rubocop to 0.39.0
+* Update Deprecated Use of property_name inside of actions

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,14 @@ gem 'nio4r', '~>1.2.1'
 
 group :spec do
   gem 'rspec', '>=3.4'
-  gem 'rubocop', '~>0.34.2'
+  gem 'rubocop', '~>0.39.0'
   gem 'foodcritic', '~>5.0.0'
   gem 'chefspec', '~>7.1.0'
 end
 
 group :integration do
   gem 'aws-sdk', '~>2.9.23'
-  gem 'test-kitchen', '~>1.15.0'
+  gem 'test-kitchen', '~>1.16.0'
   gem 'kitchen-vagrant', '~>0.19.0'
   gem 'kitchen-ec2', '~>0.10.0'
   gem 'serverspec', '~>2.29.1'

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The Windows halo version does not update automatically, the specific windows age
 Edit the following parameter's value (For Example):
 ```
 
-default['cloudpassage']['windows_installer_file_name'] = 'cphalo-4.1.0-win64.exe'
+default['cloudpassage']['windows_installer_file_name'] = 'cphalo-4.1.3-win64.exe'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # cloudpassage Cookbook
 
-Version: 4.0.2
+Version: 4.0.3
 
 Author: CloudPassage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['cloudpassage']['agent_key'] = 'abc123'
 default['cloudpassage']['grid_url'] = 'https://grid.cloudpassage.com/grid'
-default['cloudpassage']['linux_agent_version'] = '4.1.1'
+default['cloudpassage']['linux_agent_version'] = '4.1.6'
 # If you define a proxy host, you must also define the port!
 default['cloudpassage']['azure_id'] = nil
 default['cloudpassage']['proxy_host'] = nil
@@ -15,7 +15,7 @@ default['cloudpassage']['windows_installer_protocol'] = 'https'
 default['cloudpassage']['windows_installer_port'] = '443'
 default['cloudpassage']['windows_installer_host'] = 'production.packages.cloudpassage.com'
 default['cloudpassage']['windows_installer_path'] = '/windows/'
-default['cloudpassage']['windows_installer_file_name'] = 'cphalo-4.1.0-win64.exe'
+default['cloudpassage']['windows_installer_file_name'] = 'cphalo-4.1.3-win64.exe'
 default['cloudpassage']['apt_repo_url'] = 'https://production.packages.cloudpassage.com/debian'
 default['cloudpassage']['apt_repo_distribution'] = 'debian'
 default['cloudpassage']['apt_repo_components'] = ['main']

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description 'Installs/Configures CloudPassage Halo'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://support.cloudpassage.com'
 source_url 'https://github.com/cloudpassage/cloudpassage-chef-cookbook'
-version '4.0.2'
+version '4.0.3'
 chef_version '>= 12.9'
 depends 'compat_resource', '>=12.14.3'
 supports 'ubuntu', '>=12.04'

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -16,7 +16,7 @@ property :windows_installer_protocol, String, default: 'https'
 property :windows_installer_port, String, default: '443'
 property :windows_installer_host, String, default: 'production.packages.cloudpassage.com'
 property :windows_installer_path, String, default: '/windows/'
-property :windows_installer_file_name, String, default: 'cphalo-4.1.0-win64.exe'
+property :windows_installer_file_name, String, default: 'cphalo-4.1.3-win64.exe'
 property :apt_repo_url, [String, nil], default: 'https://production.packages.cloudpassage.com/debian'
 property :apt_repo_distribution, [String, nil], default: 'debian'
 property :apt_repo_components, [String, Array, nil], default: ['main']
@@ -25,29 +25,40 @@ property :apt_key_url, [String, nil], default: 'https://production.packages.clou
 property :yum_key_url, [String, nil], default: 'https://production.packages.cloudpassage.com/cloudpassage.packages.key'
 
 action :install do
-  fail 'agent_key is not set, agent will not register without one!' if agent_key.nil?
+  fail 'agent_key is not set, agent will not register without one!' if new_resource.agent_key.nil?
   hostname = node['hostname']
   label =
-    if server_label.nil? && azure_id
+    if new_resource.server_label.nil? && new_resource.azure_id
       "#{azure_id}_#{hostname}"
-    elsif server_label
-      server_label
+    elsif new_resource.server_label
+      new_resource.server_label
     else
       nil
     end
 
-  conf = { 'agent_key' => agent_key, 'grid_url' => grid_url, 'proxy_host' => proxy_host,
-           'proxy_port' => proxy_port,
-           'proxy_user' => proxy_user, 'proxy_password' => proxy_password, 'read_only' => read_only,
-           'server_tag' => server_tag, 'server_label' => label, 'dns' => dns,
-           'windows_installer_protocol' => windows_installer_protocol,
-           'windows_installer_port' => windows_installer_port,
-           'windows_installer_host' => windows_installer_host,
-           'windows_installer_path' => windows_installer_path,
-           'windows_installer_file_name' => windows_installer_file_name,
-           'apt_repo_url' => apt_repo_url, 'apt_repo_distribution' => apt_repo_distribution,
-           'apt_repo_components' => apt_repo_components, 'yum_repo_url' => yum_repo_url,
-           'apt_key_url' => apt_key_url, 'yum_key_url' => yum_key_url }
+  conf = {
+    'agent_key' => new_resource.agent_key,
+    'grid_url' => new_resource.grid_url,
+    'proxy_host' => new_resource.proxy_host,
+    'proxy_port' => new_resource.proxy_port,
+    'proxy_user' => new_resource.proxy_user,
+    'proxy_password' => new_resource.proxy_password,
+    'read_only' => new_resource.read_only,
+    'server_tag' => new_resource.server_tag,
+    'server_label' => label,
+    'dns' => new_resource.dns,
+    'windows_installer_protocol' => new_resource.windows_installer_protocol,
+    'windows_installer_port' => new_resource.windows_installer_port,
+    'windows_installer_host' => new_resource.windows_installer_host,
+    'windows_installer_path' => new_resource.windows_installer_path,
+    'windows_installer_file_name' => new_resource.windows_installer_file_name,
+    'apt_repo_url' => new_resource.apt_repo_url,
+    'apt_repo_distribution' => new_resource.apt_repo_distribution,
+    'apt_repo_components' => new_resource.apt_repo_components,
+    'yum_repo_url' => new_resource.yum_repo_url,
+    'apt_key_url' => new_resource.apt_key_url,
+    'yum_key_url' => new_resource.yum_key_url
+  }
 
   configurator = CloudPassage::ConfigHelper.new(conf)
   # First, set up repos
@@ -57,27 +68,27 @@ action :install do
     apt_package 'apt-transport-https'
 
     apt_repository 'cloudpassage' do
-      uri apt_repo_url
-      distribution apt_repo_distribution
-      components apt_repo_components
-      key apt_key_url
-      not_if apt_repo_url == '' || apt_repo_url.nil?
+      uri new_resource.apt_repo_url
+      distribution new_resource.apt_repo_distribution
+      components new_resource.apt_repo_components
+      key new_resource.apt_key_url
+      not_if new_resource.apt_repo_url == '' || new_resource.apt_repo_url.nil?
       action :add
     end
   when 'rhel', 'amazon'
     yum_repository 'cloudpassage' do
       description 'CloudPassage Halo Repository'
-      baseurl yum_repo_url
-      gpgkey yum_key_url
+      baseurl new_resource.yum_repo_url
+      gpgkey new_resource.yum_key_url
       action :create
-      not_if yum_repo_url == '' || yum_repo_url.nil?
+      not_if new_resource.yum_repo_url == '' || new_resource.yum_repo_url.nil?
     end
   end
   # Now we install...
   case node['platform_family']
   when 'debian', 'rhel', 'amazon'
     package 'cphalo' do
-      version linux_agent_version unless linux_agent_version.nil?
+      version new_resource.linux_agent_version unless new_resource.linux_agent_version.nil?
       notifies :start, 'service[CloudPassage Halo Agent for Linux]', :delayed
       action :upgrade
     end
@@ -99,7 +110,7 @@ action :install do
       action [:nothing]
     end
   when 'windows'
-    win_installer_version = windows_installer_file_name.gsub(/.*cphalo-(\d*\.\d*\.\d*)-win64.exe/, '\1')
+    win_installer_version = new_resource.windows_installer_file_name.gsub(/.*cphalo-(\d*\.\d*\.\d*)-win64.exe/, '\1')
     win_start_options = configurator.windows_configuration
     progfiles = ENV['PROGRAMW6432']
     Chef::Log.info("Detected ProgramFiles directory: #{progfiles}")
@@ -121,18 +132,29 @@ end
 
 action :reconfigure do
   fail 'agent_key is not set, keyless reconfigure is not supported!' if agent_key.nil?
-  conf = { 'agent_key' => agent_key, 'grid_url' => grid_url, 'proxy_host' => proxy_host,
-           'proxy_port' => proxy_port,
-           'proxy_user' => proxy_user, 'proxy_password' => proxy_password, 'read_only' => read_only,
-           'server_tag' => server_tag, 'server_label' => server_label, 'dns' => dns,
-           'windows_installer_protocol' => windows_installer_protocol,
-           'windows_installer_port' => windows_installer_port,
-           'windows_installer_host' => windows_installer_host,
-           'windows_installer_path' => windows_installer_path,
-           'windows_installer_file_name' => windows_installer_file_name,
-           'apt_repo_url' => apt_repo_url, 'apt_repo_distribution' => apt_repo_distribution,
-           'apt_repo_components' => apt_repo_components, 'yum_repo_url' => yum_repo_url,
-           'apt_key_url' => apt_key_url, 'yum_key_url' => yum_key_url }
+  conf = {
+    'agent_key' => new_resource.agent_key,
+    'grid_url' => new_resource.grid_url,
+    'proxy_host' => new_resource.proxy_host,
+    'proxy_port' => new_resource.proxy_port,
+    'proxy_user' => new_resource.proxy_user,
+    'proxy_password' => new_resource.proxy_password,
+    'read_only' => new_resource.read_only,
+    'server_tag' => new_resource.server_tag,
+    'server_label' => new_resource.server_label,
+    'dns' => new_resource.dns,
+    'windows_installer_protocol' => new_resource.windows_installer_protocol,
+    'windows_installer_port' => new_resource.windows_installer_port,
+    'windows_installer_host' => new_resource.windows_installer_host,
+    'windows_installer_path' => new_resource.windows_installer_path,
+    'windows_installer_file_name' => new_resource.windows_installer_file_name,
+    'apt_repo_url' => new_resource.apt_repo_url,
+    'apt_repo_distribution' => new_resource.apt_repo_distribution,
+    'apt_repo_components' => new_resource.apt_repo_components,
+    'yum_repo_url' => new_resource.yum_repo_url,
+    'apt_key_url' => new_resource.apt_key_url,
+    'yum_key_url' => new_resource.yum_key_url
+  }
 
   reconfigurator = CloudPassage::ConfigHelper.new(conf)
   case node['platform_family']


### PR DESCRIPTION
* Update Agent version to 4.1.6 (Linux) and 4.1.3 (Windows)
* Update vulnerable Gem rubocop to 0.39.0
* Update Deprecated Use of property_name inside of actions